### PR TITLE
Add gitignore to exclude Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Distribution / packaging
+build/
+dist/
+.eggs/
+*.egg-info/
+
+# Logs and coverage
+*.log
+.pytest_cache/
+
+# Temporary files
+*.swp
+*~
+.DS_Store
+
+# IDEs and editors
+.idea/
+.vscode/
+


### PR DESCRIPTION
## Summary
- add `.gitignore` to filter common Python artifacts, virtual environments and temp files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4510385c83228f2310539c56b71e