### PR TITLE
Adjust CV with explicit validation split

### DIFF
--- a/Model_8.1
+++ b/Model_8.1
@@ -38,8 +38,7 @@ import xgboost as xgb
 import yfinance as yf
 from joblib import Parallel, delayed
 from sklearn.ensemble import RandomForestClassifier, VotingClassifier
-from sklearn.metrics import precision_score, make_scorer
-from sklearn.model_selection import TimeSeriesSplit, cross_val_score
+from sklearn.metrics import precision_score
 from ta.volatility import BollingerBands
 
 # ───────────── CONFIG ─────────────
@@ -233,10 +232,13 @@ def data_prep_and_feature_engineering(
 
 def run_grid_search(X_train_sel, y_train, n_trials: int = 50):
     """Run Optuna Bayesian search and print results."""
-    precision = make_scorer(precision_score, pos_label=1, zero_division=0)
-    cv = TimeSeriesSplit(n_splits=5)
 
     def objective(trial):
+        # 80/20 time‑based split for early stopping
+        split = int(len(X_train_sel) * 0.8)
+        X_tr, X_val = X_train_sel.iloc[:split], X_train_sel.iloc[split:]
+        y_tr, y_val = y_train.iloc[:split], y_train.iloc[split:]
+
         rf = RandomForestClassifier(
             n_estimators=trial.suggest_int("n", 100, 500, 100),
             max_depth=trial.suggest_int("d", 5, 20),
@@ -258,7 +260,6 @@ def run_grid_search(X_train_sel, y_train, n_trials: int = 50):
                 random_state=42,
                 eval_metric="logloss",
             )
-            xgbc.fit(np.zeros((1, X_train_sel.shape[1])), np.array([0]))
         except xgb.core.XGBoostError:
             xgbc = xgb.XGBClassifier(
                 tree_method="hist",
@@ -270,6 +271,14 @@ def run_grid_search(X_train_sel, y_train, n_trials: int = 50):
                 eval_metric="logloss",
             )
 
+        xgbc.fit(
+            X_tr,
+            y_tr,
+            eval_set=[(X_val, y_val)],
+            early_stopping_rounds=20,
+            verbose=False,
+        )
+
         # ------- LightGBM CPU/GPU fallback -------
         try:
             lgbc = lgbm.LGBMClassifier(
@@ -279,7 +288,6 @@ def run_grid_search(X_train_sel, y_train, n_trials: int = 50):
                 subsample=trial.suggest_float("lgb_subsample", 0.5, 1.0),
                 random_state=42,
             )
-            lgbc.fit(np.zeros((10, X_train_sel.shape[1])), np.zeros(10))
         except Exception:
             lgbc = lgbm.LGBMClassifier(
                 device_type="cpu",
@@ -289,9 +297,19 @@ def run_grid_search(X_train_sel, y_train, n_trials: int = 50):
                 random_state=42,
             )
 
+        lgbc.fit(
+            X_tr,
+            y_tr,
+            eval_set=[(X_val, y_val)],
+            early_stopping_rounds=20,
+            verbose=False,
+        )
+
         vote = VotingClassifier([("rf", rf), ("xgb", xgbc), ("lgb", lgbc)], voting="soft", n_jobs=-1)
         try:
-            score = cross_val_score(vote, X_train_sel, y_train, cv=cv, scoring=precision, n_jobs=-1).mean()
+            vote.fit(X_tr, y_tr)
+            pred = vote.predict(X_val)
+            score = precision_score(y_val, pred, pos_label=1, zero_division=0)
         except Exception as e:
             print(f"Trial failed due to {e}; returning 0")
             score = 0.0


### PR DESCRIPTION
## Summary
- split data into train and validation inside `objective`
- early-stop XGBoost and LightGBM using validation set
- evaluate fitted ensemble on validation rather than cross_val_score

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f801148483229d781d235fab240a