### PR TITLE
Add get_max_profit helper and tests

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,6 +1,11 @@
-from .features import download_or_load_prices, compute_features, data_prep_and_feature_engineering
+from .features import (
+    download_or_load_prices,
+    compute_features,
+    data_prep_and_feature_engineering,
+)
 from .grid_search import run_grid_search
 from .backtest import run_backtest
+from .utils import get_max_profit
 
 __all__ = [
     "download_or_load_prices",
@@ -8,4 +13,5 @@ __all__ = [
     "data_prep_and_feature_engineering",
     "run_grid_search",
     "run_backtest",
+    "get_max_profit",
 ]

--- a/model/utils.py
+++ b/model/utils.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+__all__ = ["get_max_profit"]
+
+def get_max_profit(prices: pd.Series) -> float:
+    """Return max profit from single buy/sell transaction."""
+    if prices.empty:
+        return 0.0
+    min_price = prices.iloc[0]
+    max_profit = 0.0
+    for price in prices.iloc[1:]:
+        if price < min_price:
+            min_price = price
+        else:
+            profit = price - min_price
+            if profit > max_profit:
+                max_profit = profit
+    return float(max_profit)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from model.utils import get_max_profit
+
+
+def test_get_max_profit_normal_case():
+    prices = pd.Series([100, 90, 95, 110, 105])
+    assert get_max_profit(prices) == 20.0
+
+
+def test_get_max_profit_increasing_prices():
+    prices = pd.Series([1, 2, 3, 4, 5])
+    assert get_max_profit(prices) == 4.0
+
+
+def test_get_max_profit_decreasing_prices():
+    prices = pd.Series([5, 4, 3, 2, 1])
+    assert get_max_profit(prices) == 0.0


### PR DESCRIPTION
## Summary
- provide a `get_max_profit` utility for single buy/sell profit calculation
- expose the function in `model.__init__`
- add unit tests for normal, rising and falling price scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d84345f8832282bddd5f7e1c2de9