### PR TITLE
Fix XGBoost fit fallback

### DIFF
--- a/model/grid_search.py
+++ b/model/grid_search.py
@@ -144,7 +144,12 @@ def run_grid_search(X_train_sel, y_train, n_trials: int = 50):
         )
 
     rf.fit(X_train_sel, y_train)
-    xgbc.fit(X_train_sel, y_train)
+    try:
+        xgbc.fit(X_train_sel, y_train)
+    except xgb.core.XGBoostError:
+        print("Falling back to CPU histogram for XGBoost training")
+        xgbc = xgb.XGBClassifier(tree_method="hist", **xgb_params)
+        xgbc.fit(X_train_sel, y_train)
     lgbc.fit(X_train_sel, y_train)
 
     best_model = VotingClassifier([


### PR DESCRIPTION
## Summary
- ensure `run_grid_search` retries XGBoost training on CPU when GPU fitting fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a67d9d9c08322b5835aeff0f176b1