### PR TITLE
Remove unused constant from backtest

### DIFF
--- a/model/backtest.py
+++ b/model/backtest.py
@@ -28,7 +28,6 @@ STOP_LOSS_PCT = 0.05         # 5 % stop‑loss
 TAKE_PROFIT_PCT = 0.08       # 8 % take‑profit
 TRAIL_PCT = 0.03             # 3 % trailing stop
 EXIT_AFTER = 10              # bars after which we force an exit
-MAX_CONCURRENT = 5           # concurrent positions (position sizing handles this)
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- delete `MAX_CONCURRENT` from `model/backtest.py` since it wasn't used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a73ccf89483228110087714fd6e07